### PR TITLE
Lint to the rescue! :)

### DIFF
--- a/GameData/NeistAir/Parts/FuelTank/18Conformal/18Conformal1.cfg
+++ b/GameData/NeistAir/Parts/FuelTank/18Conformal/18Conformal1.cfg
@@ -34,8 +34,7 @@
 		{
 			model = NeistAir/Parts/FuelTank/18Conformal/18Conformal1
 		}
-	MODEL
-	
+
 	RESOURCE
 	{
 		name = LiquidFuel

--- a/GameData/NeistAir/Parts/FuelTank/18Conformal/18Conformal2.cfg
+++ b/GameData/NeistAir/Parts/FuelTank/18Conformal/18Conformal2.cfg
@@ -33,8 +33,7 @@
 		{
 			model = NeistAir/Parts/FuelTank/18Conformal/18Conformal2
 		}
-	MODEL
-	
+
 	RESOURCE
 	{
 		name = LiquidFuel

--- a/GameData/NeistAir/Parts/FuelTank/25Conformal/25Conformal1.cfg
+++ b/GameData/NeistAir/Parts/FuelTank/25Conformal/25Conformal1.cfg
@@ -34,8 +34,7 @@
 		{
 			model = NeistAir/Parts/FuelTank/25Conformal/25Conformal1
 		}
-	MODEL
-	
+
 	RESOURCE
 	{
 		name = LiquidFuel

--- a/GameData/NeistAir/Parts/FuelTank/25Conformal/25Conformal2.cfg
+++ b/GameData/NeistAir/Parts/FuelTank/25Conformal/25Conformal2.cfg
@@ -33,8 +33,7 @@
 		{
 			model = NeistAir/Parts/FuelTank/25Conformal/25Conformal2
 		}
-	MODEL
-	
+
 	RESOURCE
 	{
 		name = LiquidFuel

--- a/GameData/NeistAir/Parts/FuelTank/31Conformal/31Conformal1.cfg
+++ b/GameData/NeistAir/Parts/FuelTank/31Conformal/31Conformal1.cfg
@@ -34,8 +34,7 @@
 		{
 			model = NeistAir/Parts/FuelTank/31Conformal/31Conformal1
 		}
-	MODEL
-	
+
 	RESOURCE
 	{
 		name = LiquidFuel

--- a/GameData/NeistAir/Parts/FuelTank/31Conformal/31Conformal2.cfg
+++ b/GameData/NeistAir/Parts/FuelTank/31Conformal/31Conformal2.cfg
@@ -33,8 +33,7 @@
 		{
 			model = NeistAir/Parts/FuelTank/31Conformal/31Conformal2
 		}
-	MODEL
-	
+
 	RESOURCE
 	{
 		name = LiquidFuel

--- a/GameData/NeistAir/Parts/FuelTank/37Conformal/37Conformal1.cfg
+++ b/GameData/NeistAir/Parts/FuelTank/37Conformal/37Conformal1.cfg
@@ -34,8 +34,7 @@
 		{
 			model = NeistAir/Parts/FuelTank/37Conformal/37Conformal1
 		}
-	MODEL
-	
+
 	RESOURCE
 	{
 		name = LiquidFuel

--- a/GameData/NeistAir/Parts/FuelTank/37Conformal/37Conformal2.cfg
+++ b/GameData/NeistAir/Parts/FuelTank/37Conformal/37Conformal2.cfg
@@ -33,8 +33,7 @@
 		{
 			model = NeistAir/Parts/FuelTank/37Conformal/37Conformal2
 		}
-	MODEL
-	
+
 	RESOURCE
 	{
 		name = LiquidFuel

--- a/GameData/NeistAir/Parts/Utility/18PD/18PD.cfg
+++ b/GameData/NeistAir/Parts/Utility/18PD/18PD.cfg
@@ -8,8 +8,7 @@ PART
 		{
 			model = NeistAir/Parts/Utility/18PD/18PD
 		}
-	MODEL
-	
+
 	rescaleFactor = 1
 	
 	

--- a/GameData/NeistAir/Parts/Utility/31PD/31PD.cfg
+++ b/GameData/NeistAir/Parts/Utility/31PD/31PD.cfg
@@ -8,8 +8,7 @@ PART
 		{
 			model = NeistAir/Parts/Utility/31PD/31PD
 		}
-	MODEL
-	
+
 	rescaleFactor = 1
 	
 	node_stack_top = 0.0, 0.9375, 0.0, 0.0, 1.0, 0.0, 2

--- a/GameData/NeistAir/Parts/Utility/37PD/37PD.cfg
+++ b/GameData/NeistAir/Parts/Utility/37PD/37PD.cfg
@@ -8,8 +8,7 @@ PART
 		{
 			model = NeistAir/Parts/Utility/37PD/37PD
 		}
-	MODEL
-	
+
 	rescaleFactor = 1
 	
 	

--- a/GameData/NeistAir/Parts/Utility/PassengerCabins/25PD.cfg
+++ b/GameData/NeistAir/Parts/Utility/PassengerCabins/25PD.cfg
@@ -8,8 +8,7 @@ PART
 		{
 			model = NeistAir/Parts/Utility/PassengerCabins/25PD
 		}
-	MODEL
-	
+
 	rescaleFactor = 1
 	
 	node_stack_top = 0.0, 0.9375, 0.0, 0.0, 1.0, 0.0, 2


### PR DESCRIPTION
Hi.

I'm overhauling every single TweakScale patch in existence, and on the process I end up linting the config files from the target add'on too.

On the process, I found an empty "rogue" MODEL node name on some config files on your Airliner Parts. Since I had never seen something like this, I'm presuming this is an error and this pull request fix them.

On the other hand, if this is intentional and should not be fixed, could you please explain to me how this works? :) 

Cheers.



lint tool used: https://github.com/net-lisias-ksp/ksp-tools-public